### PR TITLE
Add strict loading

### DIFF
--- a/src/mayim/exception.py
+++ b/src/mayim/exception.py
@@ -4,3 +4,7 @@ class MayimError(Exception):
 
 class RecordNotFound(MayimError):
     ...
+
+
+class MissingSQL(MayimError):
+    ...

--- a/src/mayim/executor/base.py
+++ b/src/mayim/executor/base.py
@@ -123,7 +123,7 @@ class Executor(Generic[T]):
         return self._hydrators.get(name, self.hydrator)
 
     @classmethod
-    def _load(cls) -> None:
+    def _load(cls, strict: bool) -> None:
         ...
 
     @staticmethod

--- a/src/mayim/mayim.py
+++ b/src/mayim/mayim.py
@@ -23,6 +23,7 @@ class Mayim:
         dsn: str = "",
         hydrator: Optional[Hydrator] = None,
         pool: Optional[BaseInterface] = None,
+        strict: bool = False,
     ):
         if pool and dsn:
             raise MayimError("Conflict with pool and DSN")
@@ -40,6 +41,7 @@ class Mayim:
 
         if not executors:
             executors = []
+        self.strict = strict
         self.load(executors=executors, hydrator=hydrator, pool=pool)
 
         if hydrator is None:
@@ -69,6 +71,7 @@ class Mayim:
         executors: Sequence[Union[Type[Executor], Executor]],
         hydrator: Optional[Hydrator] = None,
         pool: Optional[BaseInterface] = None,
+        strict: Optional[bool] = None,
     ) -> None:
         """
         Look through the Executor definition for methods that should
@@ -78,6 +81,7 @@ class Mayim:
 
         to_load = set(executors)
         to_load.update(Registry().values())
+        strict = strict if strict is not None else self.strict
         for executor in to_load:
             if isclass(executor):
                 try:
@@ -98,7 +102,7 @@ class Mayim:
             if executor._loaded:
                 continue
 
-            executor._load()
+            executor._load(strict)
 
     def _get_pool_type(self, dsn: str) -> Type[BaseInterface]:
         parts = urlparse(dsn)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,7 +70,7 @@ def FooExecutor():
             ...
 
         @classmethod
-        def _load(cls):
+        def _load(cls, _):
             cls._loaded = True
 
     return FooExecutor

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -4,7 +4,7 @@ from typing import List
 import pytest
 
 from mayim import Mayim, PostgresExecutor, sql
-from mayim.exception import RecordNotFound
+from mayim.exception import MissingSQL, RecordNotFound
 
 
 async def test_empty_result_single(postgres_connection):
@@ -24,6 +24,9 @@ async def test_empty_result_single(postgres_connection):
     )
     with pytest.raises(RecordNotFound, match=message):
         await executor.select_item(item_id=999)
+    postgres_connection.execute.assert_called_with(
+        "SELECT * FROM otheritems WHERE item_id=%(item_id)s", {"item_id": 999}
+    )
 
 
 async def test_empty_result_multiple(postgres_connection):
@@ -39,3 +42,28 @@ async def test_empty_result_multiple(postgres_connection):
 
     result = await executor.select_items()
     assert result == []
+
+
+def test_missing_sql_not_strict():
+    class FooExecutor(PostgresExecutor):
+        async def select_missing(self) -> int:
+            ...
+
+    Mayim(executors=[FooExecutor()], dsn="foo://user:password@host:1234/db")
+
+
+def test_missing_sql_strict():
+    class FooExecutor(PostgresExecutor):
+        async def select_missing(self) -> int:
+            ...
+
+    message = re.escape(
+        "Could not find SQL for FooExecutor.select_missing. "
+        "Looked for file named: "
+    )
+    with pytest.raises(MissingSQL, match=message):
+        Mayim(
+            executors=[FooExecutor()],
+            dsn="foo://user:password@host:1234/db",
+            strict=True,
+        )


### PR DESCRIPTION
Closes #18 

This will raise `MissingSQL` if an executor is missing a SQL file (ignoring dynamic queries and `@sql`). This new feature will only be raised when in `strict` mode:

```python
Mayim(..., strict=True)
```

By default, this will be disabled and is currently `opt-in`. However, it very well may change in the future to strict by default.