### PR TITLE
Add counters to framework  extensions

### DIFF
--- a/src/mayim/extension/quart_extension.py
+++ b/src/mayim/extension/quart_extension.py
@@ -6,9 +6,9 @@ from typing import Optional, Sequence, Type, Union
 from mayim import Executor, Hydrator, Mayim
 from mayim.exception import MayimError
 from mayim.extension.statistics import (
-    display_counters,
+    display_statistics,
+    log_statistics_report,
     setup_qry_counter,
-    setup_qry_display,
 )
 from mayim.interface.base import BaseInterface
 from mayim.registry import InterfaceRegistry, Registry
@@ -39,7 +39,7 @@ class SQLStatisticsMiddleware:
             setup_qry_counter()
         response = await self.app(scope, receive, send)
         if scope["type"] == "http":
-            setup_qry_display(logger)
+            log_statistics_report(logger)
 
         return response
 
@@ -86,7 +86,7 @@ class QuartMayimExtension:
             for interface in InterfaceRegistry():
                 await interface.close()
 
-        if display_counters(self.counters, self.executors):
+        if display_statistics(self.counters, self.executors):
             app.asgi_app = SQLStatisticsMiddleware(  # type: ignore
                 app.asgi_app
             )

--- a/src/mayim/extension/quart_extension.py
+++ b/src/mayim/extension/quart_extension.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
-from logging import getLogger
 
+from logging import getLogger
 from typing import Optional, Sequence, Type, Union
 
 from mayim import Executor, Hydrator, Mayim

--- a/src/mayim/extension/sanic_extension.py
+++ b/src/mayim/extension/sanic_extension.py
@@ -3,9 +3,9 @@ from typing import Optional, Sequence, Type, Union
 from mayim import Executor, Hydrator, Mayim
 from mayim.exception import MayimError
 from mayim.extension.statistics import (
-    display_counters,
+    display_statistics,
+    log_statistics_report,
     setup_qry_counter,
-    setup_qry_display,
 )
 from mayim.interface.base import BaseInterface
 from mayim.registry import InterfaceRegistry, Registry
@@ -73,12 +73,12 @@ class SanicMayimExtension(Extension):
                 logger.info(f"Closing {interface}")
                 await interface.close()
 
-        if display_counters(self.counters, self.executors):
+        if display_statistics(self.counters, self.executors):
             self.app.on_request(setup_qry_counter)
 
             @self.app.on_response
             async def display(*_):
-                setup_qry_display(logger)
+                log_statistics_report(logger)
 
     def render_label(self):
         length = len(Registry())

--- a/src/mayim/extension/sanic_extension.py
+++ b/src/mayim/extension/sanic_extension.py
@@ -1,20 +1,20 @@
-from inspect import isclass
 from typing import Optional, Sequence, Type, Union
 
 from mayim import Executor, Hydrator, Mayim
 from mayim.exception import MayimError
-from mayim.extension.statistics import SQLCounterMixin
+from mayim.extension.statistics import (
+    display_counters,
+    setup_qry_counter,
+    setup_qry_display,
+)
 from mayim.interface.base import BaseInterface
 from mayim.registry import InterfaceRegistry, Registry
 
-from typing import DefaultDict
-from collections import defaultdict
 
 try:
     from sanic.log import logger
     from sanic_ext import Extend
     from sanic_ext.extensions.base import Extension
-    from sanic import Request
     from sanic.helpers import _default, Default
 
     SANIC_INSTALLED = True
@@ -74,92 +74,14 @@ class SanicMayimExtension(Extension):
                 logger.info(f"Closing {interface}")
                 await interface.close()
 
-        if self._display_counters():
-            self._init_counters()
+        if display_counters(self.counters, self.executors):
+            self.app.on_request(setup_qry_counter)
+
+            @self.app.on_response
+            async def display(*_):
+                setup_qry_display(logger)
 
     def render_label(self):
         length = len(Registry())
         s = "" if length == 1 else "s"
         return f"[{length} executor{s}]"
-
-    def _display_counters(self) -> bool:
-        if isinstance(self.counters, bool):
-            return self.counters
-
-        def _is_sql_counter(executor):
-            executor_class = (
-                executor if isclass(executor) else executor.__class__
-            )
-            return SQLCounterMixin in executor_class.mro()
-
-        return any(_is_sql_counter(executor) for executor in self.executors)
-
-    def _init_counters(self):
-        @self.app.on_request
-        async def setup_qry_counter(request: Request):
-            registry = Registry()
-            for executor in registry.values():
-                if hasattr(executor, "reset"):
-                    executor.reset()
-
-        @self.app.on_response
-        async def setup_qry_display(request: Request, _):
-            COLUMN_SIZE = 6
-            registry = Registry()
-            statistics = [
-                dict(executor._counter)
-                for executor in registry.values()
-                if hasattr(executor, "_counter")
-            ]
-            keys = list(
-                sorted(
-                    {
-                        key.rjust(COLUMN_SIZE)
-                        for executor in registry.values()
-                        if hasattr(executor, "_counter")
-                        for key in executor._counter.keys()
-                    }
-                )
-            )
-            max_executor_name = max(map(len, registry.keys()))
-            headers = " | ".join([" " * max_executor_name, *keys])
-            row_data = [
-                " | ".join(
-                    [
-                        name.rjust(max_executor_name),
-                        *[
-                            str(executor._counter.get(key, "-")).rjust(
-                                COLUMN_SIZE
-                            )
-                            for key in keys
-                        ],
-                    ]
-                )
-                for name, executor in sorted(
-                    registry.items(), key=lambda x: x[0]
-                )
-                if hasattr(executor, "_counter")
-            ]
-            if not row_data:
-                row_data = ["No executor counters found"]
-            rows = "\n".join(row_data)
-            total_values: DefaultDict[str, int] = defaultdict(int)
-            for stats in statistics:
-                for key, value in stats.items():
-                    total_values[key] += value
-            divider = "=" * len(row_data[0])
-            totals = " | ".join(
-                [
-                    "TOTALS".rjust(max_executor_name),
-                    *[
-                        str(total_values.get(key, "-")).rjust(COLUMN_SIZE)
-                        for key in keys
-                    ],
-                ]
-            )
-            title = "QUERY COUNTERS".center(len(divider))
-
-            logger.info(
-                f"SQL Statistics Report\n\n{title}\n\n{headers}\n"
-                f"{rows}\n{divider}\n{totals}\n\n"
-            )

--- a/src/mayim/extension/sanic_extension.py
+++ b/src/mayim/extension/sanic_extension.py
@@ -1,19 +1,25 @@
+from inspect import isclass
 from typing import Optional, Sequence, Type, Union
 
 from mayim import Executor, Hydrator, Mayim
 from mayim.exception import MayimError
+from mayim.extension.statistics import SQLCounterMixin
 from mayim.interface.base import BaseInterface
 from mayim.registry import InterfaceRegistry, Registry
+
+from typing import DefaultDict
+from collections import defaultdict
 
 try:
     from sanic.log import logger
     from sanic_ext import Extend
     from sanic_ext.extensions.base import Extension
+    from sanic import Request
+    from sanic.helpers import _default, Default
 
     SANIC_INSTALLED = True
 except ModuleNotFoundError:
     SANIC_INSTALLED = False
-    logger = object()  # type: ignore
     Extension = type("Extension", (), {})  # type: ignore
     Extend = type("Extend", (), {})  # type: ignore
 
@@ -28,6 +34,7 @@ class SanicMayimExtension(Extension):
         dsn: str = "",
         hydrator: Optional[Hydrator] = None,
         pool: Optional[BaseInterface] = None,
+        counters: Union[Default, bool] = _default,
     ):
         if not SANIC_INSTALLED:
             raise MayimError(
@@ -43,8 +50,17 @@ class SanicMayimExtension(Extension):
             "hydrator": hydrator,
             "pool": pool,
         }
+        self.counters = counters
 
     def startup(self, bootstrap: Extend) -> None:
+        for executor in Registry().values():
+            if isinstance(executor, Executor):
+                bootstrap.dependency(executor)
+            else:
+                bootstrap.add_dependency(
+                    executor, lambda *_: Mayim.get(executor)
+                )
+
         @self.app.before_server_start
         async def setup(_):
             Mayim(executors=self.executors, **self.mayim_kwargs)
@@ -58,15 +74,92 @@ class SanicMayimExtension(Extension):
                 logger.info(f"Closing {interface}")
                 await interface.close()
 
-        for executor in Registry().values():
-            if isinstance(executor, Executor):
-                bootstrap.dependency(executor)
-            else:
-                bootstrap.add_dependency(
-                    executor, lambda *_: Mayim.get(executor)
-                )
+        if self._display_counters():
+            self._init_counters()
 
     def render_label(self):
         length = len(Registry())
         s = "" if length == 1 else "s"
         return f"[{length} executor{s}]"
+
+    def _display_counters(self) -> bool:
+        if isinstance(self.counters, bool):
+            return self.counters
+
+        def _is_sql_counter(executor):
+            executor_class = (
+                executor if isclass(executor) else executor.__class__
+            )
+            return SQLCounterMixin in executor_class.mro()
+
+        return any(_is_sql_counter(executor) for executor in self.executors)
+
+    def _init_counters(self):
+        @self.app.on_request
+        async def setup_qry_counter(request: Request):
+            registry = Registry()
+            for executor in registry.values():
+                if hasattr(executor, "reset"):
+                    executor.reset()
+
+        @self.app.on_response
+        async def setup_qry_display(request: Request, _):
+            COLUMN_SIZE = 6
+            registry = Registry()
+            statistics = [
+                dict(executor._counter)
+                for executor in registry.values()
+                if hasattr(executor, "_counter")
+            ]
+            keys = list(
+                sorted(
+                    {
+                        key.rjust(COLUMN_SIZE)
+                        for executor in registry.values()
+                        if hasattr(executor, "_counter")
+                        for key in executor._counter.keys()
+                    }
+                )
+            )
+            max_executor_name = max(map(len, registry.keys()))
+            headers = " | ".join([" " * max_executor_name, *keys])
+            row_data = [
+                " | ".join(
+                    [
+                        name.rjust(max_executor_name),
+                        *[
+                            str(executor._counter.get(key, "-")).rjust(
+                                COLUMN_SIZE
+                            )
+                            for key in keys
+                        ],
+                    ]
+                )
+                for name, executor in sorted(
+                    registry.items(), key=lambda x: x[0]
+                )
+                if hasattr(executor, "_counter")
+            ]
+            if not row_data:
+                row_data = ["No executor counters found"]
+            rows = "\n".join(row_data)
+            total_values: DefaultDict[str, int] = defaultdict(int)
+            for stats in statistics:
+                for key, value in stats.items():
+                    total_values[key] += value
+            divider = "=" * len(row_data[0])
+            totals = " | ".join(
+                [
+                    "TOTALS".rjust(max_executor_name),
+                    *[
+                        str(total_values.get(key, "-")).rjust(COLUMN_SIZE)
+                        for key in keys
+                    ],
+                ]
+            )
+            title = "QUERY COUNTERS".center(len(divider))
+
+            logger.info(
+                f"SQL Statistics Report\n\n{title}\n\n{headers}\n"
+                f"{rows}\n{divider}\n{totals}\n\n"
+            )

--- a/src/mayim/extension/sanic_extension.py
+++ b/src/mayim/extension/sanic_extension.py
@@ -10,12 +10,11 @@ from mayim.extension.statistics import (
 from mayim.interface.base import BaseInterface
 from mayim.registry import InterfaceRegistry, Registry
 
-
 try:
+    from sanic.helpers import Default, _default
     from sanic.log import logger
     from sanic_ext import Extend
     from sanic_ext.extensions.base import Extension
-    from sanic.helpers import _default, Default
 
     SANIC_INSTALLED = True
 except ModuleNotFoundError:

--- a/src/mayim/extension/statistics.py
+++ b/src/mayim/extension/statistics.py
@@ -1,6 +1,9 @@
 from collections import defaultdict
+from inspect import isclass
+from typing import DefaultDict
 
 from mayim.executor.sql import SQLExecutor
+from mayim.registry import Registry
 
 
 class SQLCounterMixin(SQLExecutor):
@@ -19,3 +22,79 @@ class SQLCounterMixin(SQLExecutor):
         self._counter[query_type] += 1
         kwargs["name"] = name
         return super()._run_sql(*args, **kwargs)
+
+
+def display_counters(counters, executors) -> bool:
+    if isinstance(counters, bool):
+        return counters
+
+    def _is_sql_counter(executor):
+        executor_class = executor if isclass(executor) else executor.__class__
+        return SQLCounterMixin in executor_class.mro()
+
+    return any(_is_sql_counter(executor) for executor in executors)
+
+
+def setup_qry_counter(*_):
+    registry = Registry()
+    for executor in registry.values():
+        if hasattr(executor, "reset"):
+            executor.reset()
+
+
+def setup_qry_display(logger, *_):
+    COLUMN_SIZE = 6
+    registry = Registry()
+    statistics = [
+        dict(executor._counter)
+        for executor in registry.values()
+        if hasattr(executor, "_counter")
+    ]
+    keys = list(
+        sorted(
+            {
+                key.rjust(COLUMN_SIZE)
+                for executor in registry.values()
+                if hasattr(executor, "_counter")
+                for key in executor._counter.keys()
+            }
+        )
+    )
+    max_executor_name = max(map(len, registry.keys()))
+    headers = " | ".join([" " * max_executor_name, *keys])
+    row_data = [
+        " | ".join(
+            [
+                name.rjust(max_executor_name),
+                *[
+                    str(executor._counter.get(key, "-")).rjust(COLUMN_SIZE)
+                    for key in keys
+                ],
+            ]
+        )
+        for name, executor in sorted(registry.items(), key=lambda x: x[0])
+        if hasattr(executor, "_counter")
+    ]
+    if not row_data:
+        row_data = ["No executor counters found"]
+    rows = "\n".join(row_data)
+    total_values: DefaultDict[str, int] = defaultdict(int)
+    for stats in statistics:
+        for key, value in stats.items():
+            total_values[key] += value
+    divider = "=" * len(row_data[0])
+    totals = " | ".join(
+        [
+            "TOTALS".rjust(max_executor_name),
+            *[
+                str(total_values.get(key, "-")).rjust(COLUMN_SIZE)
+                for key in keys
+            ],
+        ]
+    )
+    title = "QUERY COUNTERS".center(len(divider))
+
+    logger.info(
+        f"SQL Statistics Report\n\n{title}\n\n{headers}\n"
+        f"{rows}\n{divider}\n{totals}\n\n"
+    )

--- a/src/mayim/extension/statistics.py
+++ b/src/mayim/extension/statistics.py
@@ -24,7 +24,7 @@ class SQLCounterMixin(SQLExecutor):
         return super()._run_sql(*args, **kwargs)
 
 
-def display_counters(counters, executors) -> bool:
+def display_statistics(counters, executors) -> bool:
     if isinstance(counters, bool):
         return counters
 
@@ -42,7 +42,7 @@ def setup_qry_counter(*_):
             executor.reset()
 
 
-def setup_qry_display(logger, *_):
+def log_statistics_report(logger, *_):
     COLUMN_SIZE = 6
     registry = Registry()
     statistics = [
@@ -76,7 +76,8 @@ def setup_qry_display(logger, *_):
         if hasattr(executor, "_counter")
     ]
     if not row_data:
-        row_data = ["No executor counters found"]
+        logger.warning("No executor counters found")
+        return
     rows = "\n".join(row_data)
     total_values: DefaultDict[str, int] = defaultdict(int)
     for stats in statistics:

--- a/src/mayim/extension/statistics.py
+++ b/src/mayim/extension/statistics.py
@@ -1,0 +1,21 @@
+from collections import defaultdict
+
+from mayim.executor.sql import SQLExecutor
+
+
+class SQLCounterMixin(SQLExecutor):
+    def __init__(self, *args, **kwargs) -> None:
+        self.reset()
+        super().__init__(*args, **kwargs)
+
+    def reset(self):
+        self._counter = defaultdict(int)
+
+    def _run_sql(self, *args, name: str = "", **kwargs):
+        if name and self.is_query_name(name):
+            query_type, _ = name.split("_", 1)
+        else:
+            query_type = "unknown"
+        self._counter[query_type] += 1
+        kwargs["name"] = name
+        return super()._run_sql(*args, **kwargs)


### PR DESCRIPTION
Adds a log on the end of requests (for Sanic and Quart) to display counts of executor calls.

```
[2022-07-11 11:54:34 +0300] [507026] [INFO] SQL Statistics Report

    QUERY COUNTERS   

             | select
CityExecutor |      1
=====================
      TOTALS |      1
```

```python
from mayim import PostgresExecutor
from mayim.extension.statistics import SQLCounterMixin

class CityExecutor(
    SQLCounterMixin,
    PostgresExecutor,
):
    ...
```