### PR TITLE
Add sql server support

### DIFF
--- a/docs/src/guide/install.md
+++ b/docs/src/guide/install.md
@@ -8,13 +8,11 @@ You can install Mayim using PIP:
 pip install mayim
 ```
 
-To get access to support for a specific data source, make sure you install the appropriate dependencies. You must
-install one of the following drivers.
+To get access to support for a specific data source, make sure you install the appropriate dependencies. You must install one of the following drivers.
 
 ## Postgres
 
 Dependencies:
-
 - [psycopg3](https://www.psycopg.org/psycopg3/)
 
 Either install it independently:
@@ -32,7 +30,6 @@ pip install mayim[postgres]
 ## MySQL
 
 Dependencies:
-
 - [asyncmy](https://github.com/long2ice/asyncmy)
 
 Either install it independently:
@@ -50,7 +47,6 @@ pip install mayim[mysql]
 ## SQLite
 
 Dependencies:
-
 - [aiosqlite](https://github.com/omnilib/aiosqlite)
 
 Either install it independently:
@@ -68,8 +64,7 @@ pip install mayim[sqlite]
 ## SQL Server
 
 Dependencies:
-
-- [aiosqlite](https://github.com/mkleehammer/pyodbc)
+- [pyodbc](https://github.com/mkleehammer/pyodbc)
 
 Either install it independently:
 

--- a/docs/src/guide/install.md
+++ b/docs/src/guide/install.md
@@ -8,11 +8,13 @@ You can install Mayim using PIP:
 pip install mayim
 ```
 
-To get access to support for a specific data source, make sure you install the appropriate dependencies. You must install one of the following drivers.
+To get access to support for a specific data source, make sure you install the appropriate dependencies. You must
+install one of the following drivers.
 
 ## Postgres
 
 Dependencies:
+
 - [psycopg3](https://www.psycopg.org/psycopg3/)
 
 Either install it independently:
@@ -30,6 +32,7 @@ pip install mayim[postgres]
 ## MySQL
 
 Dependencies:
+
 - [asyncmy](https://github.com/long2ice/asyncmy)
 
 Either install it independently:
@@ -47,6 +50,7 @@ pip install mayim[mysql]
 ## SQLite
 
 Dependencies:
+
 - [aiosqlite](https://github.com/omnilib/aiosqlite)
 
 Either install it independently:
@@ -59,4 +63,22 @@ Or, as a convenience:
 
 ```
 pip install mayim[sqlite]
+```
+
+## SQL Server
+
+Dependencies:
+
+- [aiosqlite](https://github.com/mkleehammer/pyodbc)
+
+Either install it independently:
+
+```
+pip install pyodbc
+```
+
+Or, as a convenience:
+
+```
+pip install mayim[sqlserver]
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,5 +42,7 @@ mysql =
     asyncmy
 sqlite =
     aiosqlite
+sqlserver =
+    pyodbc
 [options.packages.find]
 where=src

--- a/src/mayim/__init__.py
+++ b/src/mayim/__init__.py
@@ -10,6 +10,8 @@ from .sql.postgres.executor import PostgresExecutor
 from .sql.postgres.interface import PostgresPool
 from .sql.sqlite.executor import SQLiteExecutor
 from .sql.sqlite.interface import SQLitePool
+from .sql.sqlserver.executor import SQLServerExecutor
+from .sql.sqlserver.interface import SQLServerPool
 
 __version__ = version("mayim")
 
@@ -24,6 +26,8 @@ __all__ = (
     "MysqlPool",
     "PostgresExecutor",
     "SQLiteExecutor",
+    "SQLServerExecutor",
     "PostgresPool",
     "SQLitePool",
+    "SQLServerPool",
 )

--- a/src/mayim/sql/sqlserver/executor.py
+++ b/src/mayim/sql/sqlserver/executor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict, Optional, Sequence
 
 from mayim.sql.sqlserver.query import SQLServerQuery
+
 from ..executor import SQLExecutor
 
 try:
@@ -22,13 +23,13 @@ class SQLServerExecutor(SQLExecutor):
     KEYWORD_SUB = r":\2"
 
     async def _run_sql(
-            self,
-            query: str,
-            name: str = "",
-            as_list: bool = False,
-            no_result: bool = False,
-            posargs: Optional[Sequence[Any]] = None,
-            params: Optional[Dict[str, Any]] = None,
+        self,
+        query: str,
+        name: str = "",
+        as_list: bool = False,
+        no_result: bool = False,
+        posargs: Optional[Sequence[Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
     ):
         method_name = self._get_method(as_list=as_list)
         async with self.pool.connection() as conn:

--- a/src/mayim/sql/sqlserver/executor.py
+++ b/src/mayim/sql/sqlserver/executor.py
@@ -49,7 +49,6 @@ class SQLServerExecutor(SQLExecutor):
 
             results = []
             for row in raw:
-                print(row)
                 results.append(dict(zip(columns, row)))
 
             return results

--- a/src/mayim/sql/sqlserver/executor.py
+++ b/src/mayim/sql/sqlserver/executor.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Sequence
+
+from mayim.sql.sqlserver.query import SQLServerQuery
+from ..executor import SQLExecutor
+
+try:
+    import pyodbc  # noqa
+
+    SQLSERVER_ENABLED = True
+except ModuleNotFoundError:
+    SQLSERVER_ENABLED = False
+
+
+class SQLServerExecutor(SQLExecutor):
+    """Executor for interfacing with a SQL Server database"""
+
+    ENABLED = SQLSERVER_ENABLED
+    QUERY_CLASS = SQLServerQuery
+    POSITIONAL_SUB = r"?"
+    KEYWORD_SUB = r":\2"
+
+    async def _run_sql(
+            self,
+            query: str,
+            name: str = "",
+            as_list: bool = False,
+            no_result: bool = False,
+            posargs: Optional[Sequence[Any]] = None,
+            params: Optional[Dict[str, Any]] = None,
+    ):
+        method_name = self._get_method(as_list=as_list)
+        async with self.pool.connection() as conn:
+            exec_values = list(posargs) if posargs else params
+            cursor = conn.execute(query, exec_values or [])
+
+            columns = [column[0] for column in cursor.description]
+            if no_result:
+                return None
+
+            raw = getattr(cursor, method_name)()
+
+            if raw is None:
+                return None
+
+            if not as_list:
+                return dict(zip(columns, raw))
+
+            results = []
+            for row in raw:
+                print(row)
+                results.append(dict(zip(columns, row)))
+
+            return results

--- a/src/mayim/sql/sqlserver/executor.py
+++ b/src/mayim/sql/sqlserver/executor.py
@@ -41,9 +41,6 @@ class SQLServerExecutor(SQLExecutor):
 
             raw = getattr(cursor, method_name)()
 
-            if raw is None:
-                return None
-
             if not as_list:
                 return dict(zip(columns, raw))
 

--- a/src/mayim/sql/sqlserver/interface.py
+++ b/src/mayim/sql/sqlserver/interface.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 from typing import Optional
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import parse_qs, urlparse
 
 from mayim.base.interface import BaseInterface
 from mayim.exception import MayimError

--- a/src/mayim/sql/sqlserver/interface.py
+++ b/src/mayim/sql/sqlserver/interface.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Optional
+from urllib.parse import urlparse, parse_qs
+
+from mayim.base.interface import BaseInterface
+from mayim.exception import MayimError
+
+try:
+    import pyodbc
+
+    SQLSERVER_ENABLED = True
+except ModuleNotFoundError:
+    SQLSERVER_ENABLED = False
+
+
+class SQLServerPool(BaseInterface):
+    """Interface for connecting to a SQL Server database"""
+
+    scheme = "mssql+pyodbc"
+
+    def __init__(self, db_path: str):
+        self._db_path = db_path
+        super().__init__()
+
+    def _setup_pool(self):
+        if not SQLSERVER_ENABLED:
+            raise MayimError(
+                "SQL Server driver not found. Try reinstalling Mayim: "
+                "pip install mayim[sqlserver]"
+            )
+
+    def _parse_url(self) -> str:
+        url = urlparse(self._db_path)
+        query = parse_qs(url.query)
+        driver = query.get("DRIVER", "")
+        conn_string = f"DRIVER={driver};SERVER={url.hostname};PORT={url.port};DATABASE={url.path.strip('/')};UID={url.username};PWD={url.password}"
+        return conn_string
+
+    async def open(self):
+        """Open connections to the pool"""
+        conn_string = self._parse_url()
+        self._db = pyodbc.connect(conn_string)
+
+    async def close(self):
+        """Close connections to the pool"""
+        self._db.close()
+
+    @asynccontextmanager
+    async def connection(self, timeout: Optional[float] = None):
+        """Obtain a connection to the database
+
+        Args:
+            timeout (float, optional): _Not implemented_. Defaults to `None`.
+
+        Returns:
+            AsyncIterator[Connection]: Iterator that will yield a connection
+
+        Yields:
+            Iterator[AsyncIterator[Connection]]: A database connection
+        """
+        if not self._db:
+            await self.open()
+
+        yield self._db

--- a/src/mayim/sql/sqlserver/interface.py
+++ b/src/mayim/sql/sqlserver/interface.py
@@ -35,7 +35,11 @@ class SQLServerPool(BaseInterface):
         url = urlparse(self._db_path)
         query = parse_qs(url.query)
         driver = query.get("DRIVER", "")
-        conn_string = f"DRIVER={driver};SERVER={url.hostname};PORT={url.port};DATABASE={url.path.strip('/')};UID={url.username};PWD={url.password}"
+        conn_string = (
+            f"DRIVER={driver};SERVER={url.hostname};PORT={url.port};"
+            f"DATABASE={url.path.strip('/')};"
+            f"UID={url.username};PWD={url.password};"
+        )
         return conn_string
 
     async def open(self):

--- a/src/mayim/sql/sqlserver/query.py
+++ b/src/mayim/sql/sqlserver/query.py
@@ -1,0 +1,25 @@
+import re
+
+from mayim.exception import MayimError
+from mayim.sql.query import ParamType, SQLQuery
+
+
+class SQLServerQuery(SQLQuery):
+    __slots__ = ("name", "text", "param_type")
+    PATTERN_POSITIONAL_PARAMETER = re.compile(r"\?")
+    PATTERN_KEYWORD_PARAMETER = re.compile(r"\:[a-z_][a-z0-9_]")
+
+    def __init__(self, name: str, text: str) -> None:
+        super().__init__(name, text)
+        positional_argument_exists = bool(
+            self.PATTERN_POSITIONAL_PARAMETER.search(self.text)
+        )
+        keyword_argument_exists = bool(
+            self.PATTERN_KEYWORD_PARAMETER.search(self.text)
+        )
+        if keyword_argument_exists:
+            raise MayimError("Only Positional arguments allowed in pyODBC")
+        if positional_argument_exists:
+            self.param_type = ParamType.POSITIONAL
+        else:
+            self.param_type = ParamType.NONE


### PR DESCRIPTION
Hi,

I would love to use Mayim with SQL Server, so I added an SQL-Server-Executor. It uses pyODBC, which could be used for other databases as well, so a more generic executor might have been better, but it was unclear to me how to handle different connection strings. 

Right now it uses the same [url scheme](https://docs.sqlalchemy.org/en/14/dialects/mssql.html#hostname-connections) as SQLAlchemy does, e.g. `mssql+pyodbc://sa:Passw0rd@127.0.0.1/databasename?driver=ODBC+Driver+17+for+SQL+Server`. This should be documented as well, but I was unsure where exactly I should put it.

Also on code checking I get this error:

```
src/mayim/sql/sqlserver/interface.py:11: error: Cannot find implementation or library stub for module named "pyodbc"  [import]
src/mayim/sql/sqlserver/executor.py:10: error: Cannot find implementation or library stub for module named "pyodbc"  [import]
src/mayim/sql/sqlserver/executor.py:10: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports

```

It seems like pyODBC stubs are missing, I have no clue how to fix that though.

Perhaps you might want to have a look at the code and give me some tips to improve it, so it can get merged eventually.