### PR TITLE
Add global transactions

### DIFF
--- a/docs/src/guide/pydantic.md
+++ b/docs/src/guide/pydantic.md
@@ -31,7 +31,6 @@ async def run():
 
 
 asyncio.run(run())
-
 ```
 
 _(This script is complete, it should run "as is")_

--- a/src/mayim/mayim.py
+++ b/src/mayim/mayim.py
@@ -253,7 +253,10 @@ class Mayim:
                     if (
                         isclass(executor) and issubclass(executor, SQLExecutor)
                     )
-                    or isinstance(executor, SQLExecutor)
+                    or (
+                        not isclass(executor)
+                        and isinstance(executor, SQLExecutor)
+                    )
                 )
             )
         async with AsyncExitStack() as stack:

--- a/src/mayim/mayim.py
+++ b/src/mayim/mayim.py
@@ -1,4 +1,5 @@
 from asyncio import get_running_loop
+from contextlib import AsyncExitStack, asynccontextmanager
 from inspect import isclass
 from typing import Optional, Sequence, Type, TypeVar, Union
 from urllib.parse import urlparse
@@ -8,6 +9,7 @@ from mayim.base.interface import BaseInterface
 from mayim.exception import MayimError
 from mayim.lazy.interface import LazyPool
 from mayim.registry import InterfaceRegistry, Registry
+from mayim.sql.executor import SQLExecutor
 from mayim.sql.postgres.interface import PostgresPool
 
 T = TypeVar("T", bound=Executor)
@@ -237,3 +239,29 @@ class Mayim:
         """Disconnect from all database interfaces"""
         for interface in InterfaceRegistry():
             await interface.close()
+
+    @classmethod
+    @asynccontextmanager
+    async def transaction(
+        cls, *executors: Union[SQLExecutor, Type[SQLExecutor]]
+    ):
+        if not executors:
+            executors = tuple(
+                (
+                    executor
+                    for executor in Registry().values()
+                    if (
+                        isclass(executor) and issubclass(executor, SQLExecutor)
+                    )
+                    or isinstance(executor, SQLExecutor)
+                )
+            )
+        async with AsyncExitStack() as stack:
+            for maybe_executor in executors:
+                executor = (
+                    cls.get(maybe_executor)
+                    if isclass(maybe_executor)
+                    else maybe_executor
+                )
+                await stack.enter_async_context(executor.transaction())
+            yield

--- a/src/mayim/sql/executor.py
+++ b/src/mayim/sql/executor.py
@@ -156,10 +156,12 @@ class SQLExecutor(Executor[SQLQuery]):
     ):
         ...
 
-    async def rollback(self) -> None:
+    async def rollback(self, *, silent: bool = False) -> None:
         existing = self.pool.existing_connection()
         transaction = self.pool.in_transaction()
         if not existing or not transaction:
+            if silent:
+                return
             raise MayimError("Cannot rollback non-existing transaction")
         await self._rollback(existing)
 
@@ -178,7 +180,7 @@ class SQLExecutor(Executor[SQLQuery]):
             try:
                 yield
             except Exception:
-                await self.rollback()
+                await self.rollback(silent=True)
                 raise
             finally:
                 self.pool._connection.set(None)

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -1,6 +1,8 @@
+from unittest.mock import AsyncMock
 import pytest
 
 from mayim.exception import MayimError
+from mayim import Mayim
 
 
 async def test_transaction(postgres_connection, item_executor):
@@ -28,10 +30,53 @@ async def test_transaction_rollback(postgres_connection, item_executor):
     postgres_connection.rollback.assert_called_once()
 
 
-async def test_rollback_outside_transaction(
+async def test_rollback_outside_transaction_with_error(
     postgres_connection, item_executor
 ):
     message = "Cannot rollback non-existing transaction"
     with pytest.raises(MayimError, match=message):
         await item_executor.rollback()
     postgres_connection.rollback.assert_not_called()
+
+
+async def test_rollback_outside_transaction_no_error(
+    postgres_connection, item_executor
+):
+    await item_executor.rollback(silent=True)
+    postgres_connection.rollback.assert_not_called()
+
+
+async def test_global_transaction(
+    postgres_connection, ItemExecutor, item_executor, monkeypatch
+):
+    mock = AsyncMock()
+
+    with monkeypatch.context() as m:
+        m.setattr(ItemExecutor, "rollback", mock)
+        try:
+            async with Mayim.transaction():
+                raise Exception("...")
+        except Exception:
+            ...
+        postgres_connection.rollback.assert_not_called()
+        mock.assert_called_once_with(silent=True)
+        postgres_connection.rollback.reset_mock()
+        mock.reset_mock()
+
+        try:
+            async with Mayim.transaction(ItemExecutor):
+                raise Exception("...")
+        except Exception:
+            ...
+        postgres_connection.rollback.assert_not_called()
+        mock.assert_called_once_with(silent=True)
+        postgres_connection.rollback.reset_mock()
+        mock.reset_mock()
+
+        try:
+            async with Mayim.transaction(item_executor):
+                raise Exception("...")
+        except Exception:
+            ...
+        postgres_connection.rollback.assert_not_called()
+        mock.assert_called_once_with(silent=True)

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -1,8 +1,9 @@
 from unittest.mock import AsyncMock
+
 import pytest
 
-from mayim.exception import MayimError
 from mayim import Mayim
+from mayim.exception import MayimError
 
 
 async def test_transaction(postgres_connection, item_executor):


### PR DESCRIPTION
Adds transactions above the executor level.

```python
async with Mayim.transaction():
    ...
```

The above will open transactions on all executors' pools. You can limit it by passing one or more executor class or instance:

```python
second_executor = Mayim.get(SecondExecutor)
async with Mayim.transaction(FirstExecutor, second_executor):
    ...
```