### PR TITLE
Postgres SSL mode doesn't pass credentials correctly

### DIFF
--- a/src/mayim/base/interface.py
+++ b/src/mayim/base/interface.py
@@ -18,6 +18,7 @@ URLPARSE_MAPPING = {
     "password": UrlMapping("_password", str),
     "port": UrlMapping("_port", int),
     "path": UrlMapping("_db", lambda value: value.replace("/", "")),
+    "query": UrlMapping("_query", str),
 }
 
 
@@ -52,6 +53,7 @@ class BaseInterface(ABC):
         user: Optional[str] = None,
         password: Optional[str] = None,
         db: Optional[int] = None,
+        query: Optional[str] = None,
     ) -> None:
         """DB class initialization.
 
@@ -61,6 +63,7 @@ class BaseInterface(ABC):
             port (int, optional): DB port. Defaults to 6379
             password (str, optional): DB password
             db (int, optional): DB db. Defaults to 1
+            query (str, optional): DB query parameters. Defaults to None
         """
 
         if dsn and host:
@@ -92,6 +95,7 @@ class BaseInterface(ABC):
         self._user = user
         self._password = password
         self._db = db
+        self._query = query
         self._full_dsn: Optional[str] = None
         self._connection: ContextVar[Any] = ContextVar(
             "connection", default=None
@@ -138,6 +142,7 @@ class BaseInterface(ABC):
             if self.password
             else self.dsn
         )
+        self._full_dsn += f"?{self._query}" if self._query else ""
 
     @property
     def dsn(self):

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -8,7 +8,7 @@ from mayim.sql.postgres.interface import PostgresPool
 @pytest.fixture
 def mayim(FooExecutor):
     return Mayim(
-        executors=[FooExecutor], dsn="postgres://user:password@host:1234/db"
+        executors=[FooExecutor], dsn="postgres://user:password@host:1234/db?sslmode=verify-ca"
     )
 
 

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -8,7 +8,8 @@ from mayim.sql.postgres.interface import PostgresPool
 @pytest.fixture
 def mayim(FooExecutor):
     return Mayim(
-        executors=[FooExecutor], dsn="postgres://user:password@host:1234/db?sslmode=verify-ca"
+        executors=[FooExecutor],
+        dsn="postgres://user:password@host:1234/db?sslmode=verify-ca",
     )
 
 


### PR DESCRIPTION
Reference pull request only.

I'm not versed enough with this project to know if I'm doing anything correctly - this however allows me to connect to `cockroachdb` with SSL parameters and key files.